### PR TITLE
Allow negative integers as well and do not cast them to Float

### DIFF
--- a/lib/json2properties.rb
+++ b/lib/json2properties.rb
@@ -5,7 +5,7 @@ require 'active_support/core_ext/hash'
 
 class String
 	def is_i?
-		/\A\d+\z/ === self
+		/\A-?\d+\z/ === self
 	end
 
 	def is_numeric?


### PR DESCRIPTION
Looks like negative integers are considered as a floats and as a result of that if we have for example `-1`  such value is converted in the json to `-1.0` In some cases this is not what was expected. 